### PR TITLE
Xygeni-Bumper bump h2 from 1.4.200 to 2.0.202

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
         <liquibase.version>3.9.0</liquibase.version>
         <liquibase-hibernate5.version>3.8</liquibase-hibernate5.version>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.0.202</h2.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <jaxb-runtime.version>2.3.3</jaxb-runtime.version>
         <archunit-junit5.version>0.14.1</archunit-junit5.version>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
Bumps h2: 1.4.200 to 2.0.202 

## 🔍 Vulnerability Details 

- **Component:** h2 
- **Fixed Version:** 2.0.202 

## 📝 Description 

The package com.h2database:h2 from 1.4.198 and before 2.0.202 are vulnerable to XML External Entity (XXE) Injection via the org.h2.jdbc.JdbcSQLXML class object, when it receives parsed string data from org.h2.jdbc.JdbcResultSet.getSQLXML() method. If it executes the getSource() method when the parameter is DOMSource.class it will trigger the vulnerability. 

## 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-23463 

