### PR TITLE
Xygeni-Bumper - com.h2database:h2 from 1.4.200 to 2.0.206

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
         <liquibase.version>3.9.0</liquibase.version>
         <liquibase-hibernate5.version>3.8</liquibase-hibernate5.version>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.0.206</h2.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <jaxb-runtime.version>2.3.3</jaxb-runtime.version>
         <archunit-junit5.version>0.14.1</archunit-junit5.version>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
Bumps com.h2database:h2:1.4.200 to 2.0.206 

## 🔍 Vulnerability Details 

- **Component:** com.h2database:h2 
- **Fixed Version:** 2.0.206 

## 📝 Description 

The org.h2.util.JdbcUtils.getConnection method of the H2 database takes as parameters the class name of the driver and URL of the database. An attacker may pass a JNDI driver name and a URL leading to a LDAP or RMI servers, causing remote code execution. This can be exploited through various attack vectors, most notably through the H2 Console which leads to unauthenticated remote code execution. 

## 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-42392 

