### PR TITLE
Xygeni-Bumper - org.liquibase:liquibase-core from 3.9.0 to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <javassist.version>3.24.0-GA</javassist.version>
         <!-- The liquibase version should match the one managed by
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
-        <liquibase.version>3.9.0</liquibase.version>
+        <liquibase.version>4.8.0</liquibase.version>
         <liquibase-hibernate5.version>3.8</liquibase-hibernate5.version>
         <h2.version>1.4.200</h2.version>
         <validation-api.version>2.0.1.Final</validation-api.version>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
Bumps org.liquibase:liquibase-core:3.9.0 to 4.8.0 

## 🔍 Vulnerability Details 

- **Component:** org.liquibase:liquibase-core 
- **Fixed Version:** 4.8.0 

## 📝 Description 

Improper Restriction of XML External Entity Reference in GitHub repository liquibase/liquibase prior to 4.8.0. 

## 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-0839 

